### PR TITLE
Fix Date Rendering

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -10,7 +10,7 @@
             {{ end }}
             <div class="meta">
                 Written By <address>{{ .Params.authorname }}</address> &mdash;
-                <time pubdate datetime="{{ .Date.Format "2006-01-02" }}" title="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 1, 2006" }}</time>
+                <time pubdate datetime="{{ .Date.Format "2006-01-02" }}" title="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 2, 2006" }}</time>
             </div>
         </div>
         <hr>


### PR DESCRIPTION
Note the 2 after January. The 1 caused that the nth day in the month is equal to the nth month, e.g. 1st January, 2nd February... 
